### PR TITLE
Refactor: Enhance PrimarySnackBar layout and behavior

### DIFF
--- a/component/src/main/java/am/acba/component/snackbar/PrimarySnackBar.kt
+++ b/component/src/main/java/am/acba/component/snackbar/PrimarySnackBar.kt
@@ -96,19 +96,18 @@ class PrimarySnackBar(
         endIcon.setOnClickListener { swipeDown(sheetBehavior, coordinatorLayout) }
         var handlerCallback: Runnable? = coordinatorLayout.getTag(R.id.snackbar_coordinator_layout) as? Runnable
         handlerCallback?.let(coordinatorLayout::removeCallbacks)
-        if (!isUserClosable) {
-            val appearTime = (3000 + title.split(" ").size * 200).coerceAtMost(15000)
-            handlerCallback = Runnable { swipeDown(sheetBehavior, coordinatorLayout) }
-            coordinatorLayout.setTag(R.id.snackbar_coordinator_layout, handlerCallback)
-            coordinatorLayout.postDelayed(handlerCallback, (appearTime).toLong())
-        } else {
-            lifecycleOwner?.lifecycle?.addObserver(object : DefaultLifecycleObserver {
-                override fun onStop(owner: LifecycleOwner) {
-                    super.onStop(owner)
-                    endIcon.callOnClick()
-                }
-            })
-        }
+
+        val appearTime = (3000 + title.split(" ").size * 200).coerceAtMost(15000)
+        handlerCallback = Runnable { swipeDown(sheetBehavior, coordinatorLayout) }
+        coordinatorLayout.setTag(R.id.snackbar_coordinator_layout, handlerCallback)
+        coordinatorLayout.postDelayed(handlerCallback, (appearTime).toLong())
+
+        lifecycleOwner?.lifecycle?.addObserver(object : DefaultLifecycleObserver {
+            override fun onStop(owner: LifecycleOwner) {
+                super.onStop(owner)
+                endIcon.callOnClick()
+            }
+        })
     }
 
     private fun swipeUp(sheetBehavior: BottomSheetBehavior<*>) {


### PR DESCRIPTION
-   Modified `primary_snack_bar.xml`: Added `visibility="gone"` to the `end_icon` by default. Updated `tools:text` for `title` to display longer text for testing purposes.
-   Modified `PrimarySnackBar.kt`:
     - Added padding to the `snackBarTitle` based on whether it's user-closable.
    - Refactored `handlerCallback` to be calculated based on title length, up to a max of 15s, and a min of 3s.