### PR TITLE
Update layout for offer image in item_banners.xml

### DIFF
--- a/component/src/main/res/layout/item_banners.xml
+++ b/component/src/main/res/layout/item_banners.xml
@@ -11,8 +11,8 @@
         android:id="@+id/offer_image"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
-        android:minWidth="107dp"
         android:tint="@null"
+        android:scaleType="fitStart"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
Changed the layout of the offer image in `item_banners.xml` by removing `android:minWidth="107dp"` and adding `android:scaleType="fitStart"`.