### PR TITLE
Refactor: Introduce composableView and Modifier.id extensions

### DIFF
--- a/app/src/main/java/am/acba/composeComponents/base/BaseComposeFragment.kt
+++ b/app/src/main/java/am/acba/composeComponents/base/BaseComposeFragment.kt
@@ -1,6 +1,7 @@
 ﻿package am.acba.composeComponents.base
 
 import am.acba.components.mainScreen.MainActivity
+import am.acba.compose.composableView
 import am.acba.compose.theme.DigitalTheme
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -14,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.fragment.app.Fragment
@@ -26,9 +26,9 @@ abstract class BaseComposeFragment : Fragment() {
     @Composable
     abstract fun SetContent()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View = ComposeView(inflater.context).apply {
-        title = arguments?.getString("Title") ?: ""
-        setContent {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
+        requireContext().composableView {
+            title = arguments?.getString("Title") ?: ""
             DigitalTheme(MainActivity.darkTheme) {
                 focusManager = LocalFocusManager.current
                 val keyboardController = LocalSoftwareKeyboardController.current
@@ -50,7 +50,7 @@ abstract class BaseComposeFragment : Fragment() {
                 }
             }
         }
-    }
+
 
     fun clearFocus() {
         focusManager.clearFocus()

--- a/component/src/main/java/am/acba/compose/ComposeExtensions.kt
+++ b/component/src/main/java/am/acba/compose/ComposeExtensions.kt
@@ -1,0 +1,23 @@
+﻿@file:OptIn(ExperimentalComposeUiApi::class)
+
+package am.acba.compose
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.UiComposable
+import androidx.compose.ui.platform.ComposeView
+
+fun Context.composableView(
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    content: @Composable @UiComposable () -> Unit = {}
+): ComposeView =
+    ComposeView(
+        context = this,
+        attrs = attrs,
+        defStyleAttr = defStyleAttr
+    ).apply {
+        setContent(content)
+    }

--- a/component/src/main/java/am/acba/compose/ModifierExtensions.kt
+++ b/component/src/main/java/am/acba/compose/ModifierExtensions.kt
@@ -1,0 +1,15 @@
+﻿@file:OptIn(ExperimentalComposeUiApi::class)
+
+package am.acba.compose
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+
+fun Modifier.id(id: String): Modifier {
+    return this then Modifier
+        .semantics { testTagsAsResourceId = true }
+        .testTag(id)
+}

--- a/component/src/main/java/am/acba/compose/components/PrimatyToolbar.kt
+++ b/component/src/main/java/am/acba/compose/components/PrimatyToolbar.kt
@@ -2,6 +2,7 @@ package am.acba.compose.components
 
 import am.acba.component.R
 import am.acba.component.extensions.getActivity
+import am.acba.compose.id
 import am.acba.compose.theme.DigitalTheme
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
@@ -10,55 +11,36 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PrimaryToolbar(
     title: String = "",
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     val activity = LocalContext.current.getActivity()
-    TopAppBar(
-        title = {
-            PrimaryText(
-                modifier = Modifier
-                    .padding(end = 16.dp, start = 16.dp)
-                    .semantics {
-                        testTagsAsResourceId = true
-                    }
-                    .testTag("android:id/centre_title"),
-                text = title,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        },
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = DigitalTheme.colorScheme.backgroundBase,
-            titleContentColor = DigitalTheme.colorScheme.contentPrimary,
-        ),
-        actions = actions,
-        navigationIcon = {
-            IconButton(onClick = {
-                activity?.onBackPressed()
-            }, modifier = Modifier
-                .semantics {
-                    testTagsAsResourceId = true
-                }
-                .testTag("android:id/leftIcon")) {
-                PrimaryIcon(painterResource(R.drawable.ic_back))
-            }
+    TopAppBar(title = {
+        PrimaryText(
+            modifier = Modifier
+                .padding(end = 16.dp, start = 16.dp)
+                .id("android:id/centre_title"), text = title, maxLines = 1, overflow = TextOverflow.Ellipsis
+        )
+    }, colors = TopAppBarDefaults.topAppBarColors(
+        containerColor = DigitalTheme.colorScheme.backgroundBase,
+        titleContentColor = DigitalTheme.colorScheme.contentPrimary,
+    ), actions = actions, navigationIcon = {
+        IconButton(onClick = {
+            activity?.onBackPressed()
+        }, modifier = Modifier.id("android:id/leftIcon")) {
+            PrimaryIcon(painterResource(R.drawable.ic_back))
         }
-    )
+    })
 }
 
 @Composable

--- a/component/src/main/java/am/acba/compose/components/listItem/ListItem.kt
+++ b/component/src/main/java/am/acba/compose/components/listItem/ListItem.kt
@@ -15,6 +15,7 @@ import am.acba.compose.components.controls.PrimaryCheckbox
 import am.acba.compose.components.controls.PrimaryRadioButton
 import am.acba.compose.components.controls.PrimarySwitch
 import am.acba.compose.components.divider.PrimaryDivider
+import am.acba.compose.id
 import am.acba.compose.theme.DigitalTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -34,9 +35,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
@@ -154,8 +152,7 @@ fun ListItem(
                 ) {
                     Avatar(
                         backgroundModifier = avatarBackgroundModifier
-                            .semantics { testTagsAsResourceId = true }
-                            .testTag("android:id/startIcon"),
+                            .id("android:id/startIcon"),
                         badgeModifier = avatarBadgeModifier,
                         contentModifier = avatarContentModifier,
                         avatarType = avatarType,
@@ -191,8 +188,7 @@ fun ListItem(
                         modifier = Modifier
                             .weight(1f)
                             .align(if (isTitleOnly) Alignment.CenterVertically else Alignment.Top)
-                            .semantics { testTagsAsResourceId = true }
-                            .testTag("android:id/title"),
+                            .id("android:id/title"),
                         text = title,
                         color = titleColor ?: listItemType.getTitleTextColor(),
                         style = titleStyle ?: listItemType.getTitleStyle(),
@@ -208,8 +204,7 @@ fun ListItem(
                             iconColor = badgeIconColor,
                             badgeBorderColor = badgeBorderColor,
                             modifier = badgeModifier
-                                .semantics { testTagsAsResourceId = true }
-                                .testTag("android:id/badge"),
+                                .id("android:id/badge"),
                             text = badgeText,
                             textColor = badgeTextColor
                         )
@@ -225,8 +220,7 @@ fun ListItem(
                             iconColor = endIconColor,
                             iconPadding = endIconPadding.dp,
                             backgroundModifier = Modifier
-                                .semantics { testTagsAsResourceId = true }
-                                .testTag("android:id/endIcon")
+                                .id("android:id/endIcon")
                         )
                     }
                     if (endIconSecond != null) {
@@ -240,8 +234,7 @@ fun ListItem(
                             iconColor = endIconSecondColor,
                             iconPadding = endIconSecondPadding.dp,
                             backgroundModifier = Modifier
-                                .semantics { testTagsAsResourceId = true }
-                                .testTag("android:id/endIconSecond")
+                                .id("android:id/endIconSecond")
                         )
                     }
 
@@ -251,22 +244,22 @@ fun ListItem(
                             state = if (controllerSelected) ToggleableState.On else ToggleableState.Off,
                             onClick = { onCheckedChangeListener.invoke(it == ToggleableState.On) },
                             modifier = Modifier
-                                .semantics { testTagsAsResourceId = true }
-                                .testTag("android:id/listItemCheckbox"))
+                                .id("android:id/listItemCheckbox")
+                        )
 
                         ControllerTypeEnum.RADIO_BUTTON -> PrimaryRadioButton(
                             selected = controllerSelected,
                             onClick = onRadioButtonClick,
                             modifier = Modifier
-                                .semantics { testTagsAsResourceId = true }
-                                .testTag("android:id/listItemRadioButton"))
+                                .id("android:id/listItemRadioButton")
+                        )
 
                         ControllerTypeEnum.SWITCH -> PrimarySwitch(
                             checked = controllerSelected,
                             onCheckedChange = { onCheckedChangeListener.invoke(it) },
                             modifier = Modifier
-                                .semantics { testTagsAsResourceId = true }
-                                .testTag("android:id/listItemSwitcher"))
+                                .id("android:id/listItemSwitcher")
+                        )
                     }
                 }
                 val newDescriptions = arrayListOf(description, description2, description3, description4).filter { it.isNotEmpty() }
@@ -296,8 +289,7 @@ fun ListItem(
                         maxLines = firstDescriptionMaxLines,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .semantics { testTagsAsResourceId = true }
-                            .testTag("android:id/description")
+                            .id("android:id/description")
                     )
                 }
                 if (newDescription2.isNotEmpty()) {
@@ -308,8 +300,7 @@ fun ListItem(
                         maxLines = secondDescriptionMaxLines,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .semantics { testTagsAsResourceId = true }
-                            .testTag("android:id/description2")
+                            .id("android:id/description2")
                     )
                 }
                 if (newDescription3.isNotEmpty()) {
@@ -320,8 +311,7 @@ fun ListItem(
                         maxLines = thirdDescriptionMaxLines,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .semantics { testTagsAsResourceId = true }
-                            .testTag("android:id/description3")
+                            .id("android:id/description3")
                     )
                 }
                 if (newDescription4.isNotEmpty()) {
@@ -332,8 +322,7 @@ fun ListItem(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .semantics { testTagsAsResourceId = true }
-                            .testTag("android:id/description4")
+                            .id("android:id/description4")
                     )
                 }
             }


### PR DESCRIPTION
This commit introduces two new extension functions to simplify Compose development:

1.  **`Context.composableView`:**
    *   Creates and configures a `ComposeView` with optional attributes and default style.
    *   Replaces the direct `ComposeView` instantiation in `BaseComposeFragment`.

2.  **`Modifier.id`:**
    *   Provides a concise way to set `testTag` and enable `testTagsAsResourceId` for UI testing.
    *   Applied to various components in `ListItem.kt` and `PrimaryToolbar.kt` to simplify test ID assignment.

**Key changes:**

*   **New `ComposeExtensions.kt`:**
    *   Added `composableView` extension function.
*   **New `ModifierExtensions.kt`:**
    *   Added `id` extension function.
*   **`BaseComposeFragment.kt`:**
    *   Replaced `ComposeView(inflater.context).apply { ... }` with `requireContext().composableView { ... }`.
*   **`ListItem.kt`:**
    *   Replaced `Modifier.semantics { testTagsAsResourceId = true }.testTag("...")` with `Modifier.id("...")` for elements like start icon, title, badge, end icons, controller types, and descriptions.
*   **`PrimaryToolbar.kt`:**
    *   Replaced `Modifier.semantics { testTagsAsResourceId = true }.testTag("...")` with `Modifier.id("...")` for the center title and left icon.
    *   Removed `@OptIn(ExperimentalComposeUiApi::class)` as it's now handled by the `id` extension.