### PR TITLE
feat(CollapsingToolbar): Introduce CollapsingToolbar and related comp…

### DIFF
--- a/app/src/main/java/am/acba/components/mainScreen/ComponentTypeEnum.kt
+++ b/app/src/main/java/am/acba/components/mainScreen/ComponentTypeEnum.kt
@@ -72,7 +72,7 @@ enum class ComponentTypeEnum(val componentName: String, val isCompose: Boolean, 
     TIME_LINE("TimeLine", false, R.id.timeLineFragment),
     TIME_LINE_COMPOSE("TimeLine", true, R.id.timeLineComposeFragment, isReady = true),
     TOOLBAR("Toolbar", false, R.id.toolbarFragment),
-    TOOLBAR_COMPOSE("Toolbar", true, R.id.toolbarComposeFragment);
+    TOOLBAR_COMPOSE("Toolbar", true, R.id.toolbarComposeFragment, isReady = true);
 
     companion object {
         fun getComponentsList(isCompose: Boolean) =

--- a/app/src/main/java/am/acba/composeComponents/toolbar/ToolbarScreen.kt
+++ b/app/src/main/java/am/acba/composeComponents/toolbar/ToolbarScreen.kt
@@ -1,6 +1,5 @@
 ﻿package am.acba.composeComponents.toolbar
 
-import am.acba.compose.components.collapsingToolbar.CollapsingTitle
 import am.acba.compose.components.collapsingToolbar.CollapsingToolbar
 import am.acba.compose.components.collapsingToolbar.rememberToolbarScrollBehavior
 import am.acba.compose.components.listItem.ListItem
@@ -44,7 +43,7 @@ fun ToolbarScreen(title: String = "") {
                 .nestedScroll(scrollBehavior.nestedScrollConnection)
         ) {
             CollapsingToolbar(
-                collapsingTitle = CollapsingTitle("Toolbar title Toolbar title Toolbar title", DigitalTheme.typography.heading5Bold),
+                title = "Toolbar title Toolbar title Toolbar title",
                 scrollBehavior = scrollBehavior
             )
             LazyColumn(modifier = Modifier) {

--- a/app/src/main/java/am/acba/composeComponents/toolbar/ToolbarScreen.kt
+++ b/app/src/main/java/am/acba/composeComponents/toolbar/ToolbarScreen.kt
@@ -1,8 +1,9 @@
 ﻿package am.acba.composeComponents.toolbar
 
-import am.acba.component.R
-import am.acba.compose.components.PrimaryIcon
-import am.acba.compose.components.PrimaryToolbar
+import am.acba.compose.components.collapsingToolbar.CollapsingTitle
+import am.acba.compose.components.collapsingToolbar.CollapsingToolbar
+import am.acba.compose.components.collapsingToolbar.rememberToolbarScrollBehavior
+import am.acba.compose.components.listItem.ListItem
 import am.acba.compose.theme.DigitalTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -12,16 +13,15 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,20 +37,28 @@ fun ToolbarScreen(title: String = "") {
                     .calculateBottomPadding()
             )
     ) {
-        Column(Modifier.fillMaxSize()) {
-            PrimaryToolbar(title = title, actions = {
-                IconButton(onClick = {
+        val scrollBehavior = rememberToolbarScrollBehavior()
+        Column(
+            Modifier
+                .fillMaxSize()
+                .nestedScroll(scrollBehavior.nestedScrollConnection)
+        ) {
+            CollapsingToolbar(
+                collapsingTitle = CollapsingTitle("Toolbar title Toolbar title Toolbar title", DigitalTheme.typography.heading5Bold),
+                scrollBehavior = scrollBehavior
+            )
+            LazyColumn(modifier = Modifier) {
+                items((0..20).toList()) {
+                    ListItem(
+                        title = "List item $it",
+                        titleStyle = DigitalTheme.typography.body1Regular,
+                        backgroundColor = Color.Transparent,
+                        showDivider = true,
+                        onClick = {
 
-                }) {
-                    PrimaryIcon(painterResource(R.drawable.ic_settings))
+                        }
+                    )
                 }
-            })
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp)
-                    .verticalScroll(rememberScrollState()),
-            ) {
             }
         }
     }

--- a/component/src/main/java/am/acba/compose/components/collapsingToolbar/CollapsingToolbar.kt
+++ b/component/src/main/java/am/acba/compose/components/collapsingToolbar/CollapsingToolbar.kt
@@ -1,0 +1,329 @@
+﻿@file:OptIn(ExperimentalMaterial3Api::class)
+
+package am.acba.compose.components.collapsingToolbar
+
+import am.acba.component.R
+import am.acba.component.extensions.getActivity
+import am.acba.compose.components.PrimaryIcon
+import am.acba.compose.components.PrimaryText
+import am.acba.compose.id
+import am.acba.compose.theme.DigitalTheme
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+@Composable
+fun CollapsingToolbar(
+    modifier: Modifier = Modifier,
+    actions: (@Composable RowScope.() -> Unit)? = null,
+    centralContent: (@Composable () -> Unit)? = null,
+    additionalContent: (@Composable () -> Unit)? = null,
+    collapsingTitle: CollapsingTitle? = null,
+    scrollBehavior: CollapsingToolbarScrollBehavior? = null,
+) {
+    val collapsedFraction = when {
+        scrollBehavior != null && centralContent == null -> scrollBehavior.state.collapsedFraction
+        scrollBehavior != null && centralContent != null -> 0f
+        else -> 1f
+    }
+
+    val fullyCollapsedTitleScale = when {
+        collapsingTitle != null -> CollapsedTitleLineHeight.value / collapsingTitle.expandedTextStyle.lineHeight.value
+        else -> 1f
+    }
+
+    val collapsingTitleScale = lerp(1f, fullyCollapsedTitleScale, collapsedFraction)
+
+    Surface(
+        modifier = modifier
+            .background(DigitalTheme.colorScheme.backgroundBase)
+            .padding(
+                top = TopAppBarDefaults.windowInsets
+                    .only(WindowInsetsSides.Top)
+                    .asPaddingValues()
+                    .calculateTopPadding()
+            ),
+    ) {
+        Layout(
+            content = {
+                if (collapsingTitle != null) {
+                    PrimaryText(
+                        modifier = Modifier
+                            .layoutId(ExpandedTitleId)
+                            .wrapContentHeight(align = Alignment.Top)
+                            .graphicsLayer(
+                                scaleX = collapsingTitleScale,
+                                scaleY = collapsingTitleScale,
+                                transformOrigin = TransformOrigin(0f, 0f)
+                            ),
+                        text = collapsingTitle.titleText,
+                        style = collapsingTitle.expandedTextStyle
+                    )
+                    PrimaryText(
+                        modifier = Modifier
+                            .layoutId(CollapsedTitleId)
+                            .wrapContentHeight(align = Alignment.Top)
+                            .graphicsLayer(
+                                scaleX = collapsingTitleScale,
+                                scaleY = collapsingTitleScale,
+                                transformOrigin = TransformOrigin(0f, 0f)
+                            ),
+                        text = collapsingTitle.titleText,
+                        style = collapsingTitle.expandedTextStyle,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                Box(
+                    modifier = Modifier
+                        .wrapContentSize()
+                        .layoutId(NavigationIconId)
+                ) {
+                    val activity = LocalContext.current.getActivity()
+                    IconButton(onClick = {
+                        activity?.onBackPressed()
+                    }, modifier = Modifier.id("leftIcon")) {
+                        PrimaryIcon(painterResource(R.drawable.ic_back))
+                    }
+
+                }
+
+                if (actions != null) {
+                    Row(
+                        modifier = Modifier
+                            .wrapContentSize()
+                            .layoutId(ActionsId)
+                    ) {
+                        actions()
+                    }
+                }
+
+                if (centralContent != null) {
+                    Box(
+                        modifier = Modifier
+                            .wrapContentSize()
+                            .layoutId(CentralContentId)
+                    ) {
+                        centralContent()
+                    }
+                }
+
+                if (additionalContent != null) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .layoutId(AdditionalContentId)
+                    ) {
+                        additionalContent()
+                    }
+                }
+            },
+            modifier = modifier
+                .background(DigitalTheme.colorScheme.backgroundBase)
+                .then(Modifier.heightIn(min = MinCollapsedHeight))
+        ) { measurables, constraints ->
+            val horizontalPaddingPx = HorizontalPadding.toPx()
+            val titleHorizontalPaddingPx = TitleHorizontalPadding.toPx()
+            val expandedTitleBottomPaddingPx = ExpandedTitleBottomPadding.toPx()
+
+
+            // Measuring widgets inside toolbar:
+
+            val navigationIconPlaceable = measurables.firstOrNull { it.layoutId == NavigationIconId }
+                ?.measure(constraints.copy(minWidth = 0))
+
+            val actionsPlaceable = measurables.firstOrNull { it.layoutId == ActionsId }
+                ?.measure(constraints.copy(minWidth = 0))
+
+            val expandedTitlePlaceable = measurables.firstOrNull { it.layoutId == ExpandedTitleId }
+                ?.measure(
+                    constraints.copy(
+                        maxWidth = (constraints.maxWidth - 2 * titleHorizontalPaddingPx).roundToInt(),
+                        minWidth = 0,
+                        minHeight = 0
+                    )
+                )
+
+            val additionalContentPlaceable = measurables.firstOrNull { it.layoutId == AdditionalContentId }
+                ?.measure(constraints)
+
+            val navigationIconOffset = when (navigationIconPlaceable) {
+                null -> horizontalPaddingPx
+                else -> navigationIconPlaceable.width + horizontalPaddingPx * 2
+            }
+
+            val actionsOffset = when (actionsPlaceable) {
+                null -> horizontalPaddingPx
+                else -> actionsPlaceable.width + horizontalPaddingPx * 2
+            }
+
+            val collapsedTitleMaxWidthPx =
+                (constraints.maxWidth - navigationIconOffset - titleHorizontalPaddingPx - actionsOffset) / fullyCollapsedTitleScale
+
+            val collapsedTitlePlaceable = measurables.firstOrNull { it.layoutId == CollapsedTitleId }
+                ?.measure(
+                    constraints.copy(
+                        maxWidth = collapsedTitleMaxWidthPx.roundToInt(),
+                        minWidth = 0,
+                        minHeight = 0
+                    )
+                )
+
+            val centralContentPlaceable = measurables.firstOrNull { it.layoutId == CentralContentId }
+                ?.measure(
+                    constraints.copy(
+                        minWidth = 0,
+                        maxWidth = (constraints.maxWidth - navigationIconOffset - actionsOffset).roundToInt()
+                    )
+                )
+
+            val collapsedHeightPx = when {
+                centralContentPlaceable != null ->
+                    max(MinCollapsedHeight.toPx(), centralContentPlaceable.height.toFloat())
+
+                else -> MinCollapsedHeight.toPx()
+            }
+
+            var layoutHeightPx = collapsedHeightPx
+
+
+            // Calculating coordinates of widgets inside toolbar:
+
+            // Current coordinates of navigation icon
+            val navigationIconX = horizontalPaddingPx.roundToInt()
+            val navigationIconY = ((collapsedHeightPx - (navigationIconPlaceable?.height ?: 0)) / 2).roundToInt()
+
+            // Current coordinates of actions
+            val actionsX = (constraints.maxWidth - (actionsPlaceable?.width ?: 0) - horizontalPaddingPx).roundToInt()
+            val actionsY = ((collapsedHeightPx - (actionsPlaceable?.height ?: 0)) / 2).roundToInt()
+
+            // Current coordinates of title
+            var collapsingTitleY = 0
+            var collapsingTitleX = 0
+
+            if (expandedTitlePlaceable != null && collapsedTitlePlaceable != null) {
+                // Measuring toolbar collapsing distance
+                val heightOffsetLimitPx = expandedTitlePlaceable.height + expandedTitleBottomPaddingPx
+                scrollBehavior?.state?.heightOffsetLimit = when (centralContent) {
+                    null -> -heightOffsetLimitPx
+                    else -> -1f
+                }
+
+                // Toolbar height at fully expanded state
+                val fullyExpandedHeightPx = MinCollapsedHeight.toPx() + heightOffsetLimitPx
+
+                // Coordinates of fully expanded title
+                val fullyExpandedTitleX = titleHorizontalPaddingPx
+                val fullyExpandedTitleY =
+                    fullyExpandedHeightPx - expandedTitlePlaceable.height - expandedTitleBottomPaddingPx
+
+                // Coordinates of fully collapsed title
+                val fullyCollapsedTitleX = navigationIconOffset + 20.dp.toPx()
+                val fullyCollapsedTitleY = collapsedHeightPx / 2 - CollapsedTitleLineHeight.toPx().roundToInt() / 2
+
+                // Current height of toolbar
+                layoutHeightPx = lerp(fullyExpandedHeightPx, collapsedHeightPx, collapsedFraction)
+
+                // Current coordinates of collapsing title
+                collapsingTitleX = lerp(fullyExpandedTitleX, fullyCollapsedTitleX, collapsedFraction).roundToInt()
+                collapsingTitleY = lerp(fullyExpandedTitleY, fullyCollapsedTitleY, collapsedFraction).roundToInt()
+            } else {
+                scrollBehavior?.state?.heightOffsetLimit = -1f
+            }
+
+            val toolbarHeightPx = layoutHeightPx.roundToInt() + (additionalContentPlaceable?.height ?: 0)
+
+
+            // Placing toolbar widgets:
+
+            layout(constraints.maxWidth, toolbarHeightPx) {
+                navigationIconPlaceable?.placeRelative(
+                    x = navigationIconX,
+                    y = navigationIconY
+                )
+                actionsPlaceable?.placeRelative(
+                    x = actionsX,
+                    y = actionsY
+                )
+                centralContentPlaceable?.placeRelative(
+                    x = navigationIconOffset.roundToInt(),
+                    y = ((collapsedHeightPx - centralContentPlaceable.height) / 2).roundToInt()
+                )
+                if (expandedTitlePlaceable?.width == collapsedTitlePlaceable?.width) {
+                    expandedTitlePlaceable?.placeRelative(
+                        x = collapsingTitleX,
+                        y = collapsingTitleY,
+                    )
+                } else {
+                    expandedTitlePlaceable?.placeRelativeWithLayer(
+                        x = collapsingTitleX,
+                        y = collapsingTitleY,
+                        layerBlock = { alpha = 1 - collapsedFraction }
+                    )
+                    collapsedTitlePlaceable?.placeRelativeWithLayer(
+                        x = collapsingTitleX,
+                        y = collapsingTitleY,
+                        layerBlock = { alpha = collapsedFraction }
+                    )
+                }
+                additionalContentPlaceable?.placeRelative(
+                    x = 0,
+                    y = layoutHeightPx.roundToInt()
+                )
+            }
+        }
+
+    }
+}
+
+
+private fun lerp(a: Float, b: Float, fraction: Float): Float {
+    return a + fraction * (b - a)
+}
+
+data class CollapsingTitle(
+    val titleText: String,
+    val expandedTextStyle: TextStyle,
+)
+
+private val MinCollapsedHeight = 56.dp
+private val HorizontalPadding = 2.dp
+private val TitleHorizontalPadding = 16.dp
+private val ExpandedTitleBottomPadding = 8.dp
+private val CollapsedTitleLineHeight = 24.sp
+
+private const val ExpandedTitleId = "expandedTitle"
+private const val CollapsedTitleId = "collapsedTitle"
+private const val NavigationIconId = "navigationIcon"
+private const val ActionsId = "actions"
+private const val CentralContentId = "centralContent"
+private const val AdditionalContentId = "additionalContent"

--- a/component/src/main/java/am/acba/compose/components/collapsingToolbar/CollapsingToolbar.kt
+++ b/component/src/main/java/am/acba/compose/components/collapsingToolbar/CollapsingToolbar.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -43,10 +42,10 @@ import kotlin.math.roundToInt
 @Composable
 fun CollapsingToolbar(
     modifier: Modifier = Modifier,
+    title: String? = null,
     actions: (@Composable RowScope.() -> Unit)? = null,
     centralContent: (@Composable () -> Unit)? = null,
     additionalContent: (@Composable () -> Unit)? = null,
-    collapsingTitle: CollapsingTitle? = null,
     scrollBehavior: CollapsingToolbarScrollBehavior? = null,
 ) {
     val collapsedFraction = when {
@@ -56,7 +55,7 @@ fun CollapsingToolbar(
     }
 
     val fullyCollapsedTitleScale = when {
-        collapsingTitle != null -> CollapsedTitleLineHeight.value / collapsingTitle.expandedTextStyle.lineHeight.value
+        title != null -> CollapsedTitleLineHeight.value / DigitalTheme.typography.heading5Bold.lineHeight.value
         else -> 1f
     }
 
@@ -74,7 +73,7 @@ fun CollapsingToolbar(
     ) {
         Layout(
             content = {
-                if (collapsingTitle != null) {
+                if (title != null) {
                     PrimaryText(
                         modifier = Modifier
                             .layoutId(ExpandedTitleId)
@@ -84,8 +83,8 @@ fun CollapsingToolbar(
                                 scaleY = collapsingTitleScale,
                                 transformOrigin = TransformOrigin(0f, 0f)
                             ),
-                        text = collapsingTitle.titleText,
-                        style = collapsingTitle.expandedTextStyle
+                        text = title,
+                        style = DigitalTheme.typography.heading5Bold
                     )
                     PrimaryText(
                         modifier = Modifier
@@ -96,8 +95,8 @@ fun CollapsingToolbar(
                                 scaleY = collapsingTitleScale,
                                 transformOrigin = TransformOrigin(0f, 0f)
                             ),
-                        text = collapsingTitle.titleText,
-                        style = collapsingTitle.expandedTextStyle,
+                        text = title,
+                        style = DigitalTheme.typography.heading5Bold,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -309,11 +308,6 @@ fun CollapsingToolbar(
 private fun lerp(a: Float, b: Float, fraction: Float): Float {
     return a + fraction * (b - a)
 }
-
-data class CollapsingTitle(
-    val titleText: String,
-    val expandedTextStyle: TextStyle,
-)
 
 private val MinCollapsedHeight = 56.dp
 private val HorizontalPadding = 2.dp

--- a/component/src/main/java/am/acba/compose/components/collapsingToolbar/CollapsingToolbarScrollBehavior.kt
+++ b/component/src/main/java/am/acba/compose/components/collapsingToolbar/CollapsingToolbarScrollBehavior.kt
@@ -1,0 +1,142 @@
+﻿package am.acba.compose.components.collapsingToolbar
+
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.DecayAnimationSpec
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDecay
+import androidx.compose.animation.core.animateTo
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
+import kotlin.math.abs
+
+class CollapsingToolbarScrollBehavior(
+    val state: CollapsingToolbarScrollState,
+    val flingAnimationSpec: DecayAnimationSpec<Float>?,
+) {
+
+    val nestedScrollConnection = object : NestedScrollConnection {
+
+        override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+            // Don't intercept if scrolling down.
+            if (available.y > 0f) return Offset.Zero
+
+            val prevHeightOffset = state.heightOffset
+            state.heightOffset += available.y
+            return if (prevHeightOffset != state.heightOffset) {
+                // We're in the middle of top app bar collapse or expand.
+                // Consume only the scroll on the Y axis.
+                available.copy(x = 0f)
+            } else {
+                Offset.Zero
+            }
+        }
+
+        override fun onPostScroll(
+            consumed: Offset,
+            available: Offset,
+            source: NestedScrollSource,
+        ): Offset {
+            state.contentOffset += consumed.y
+
+            if (available.y < 0f || consumed.y < 0f) {
+                // When scrolling up, just update the state's height offset.
+                val oldHeightOffset = state.heightOffset
+                state.heightOffset += consumed.y
+                return Offset(0f, state.heightOffset - oldHeightOffset)
+            }
+
+            if (consumed.y == 0f && available.y > 0) {
+                // Reset the total content offset to zero when scrolling all the way down. This
+                // will eliminate some float precision inaccuracies.
+                state.contentOffset = 0f
+            }
+
+            if (available.y > 0f) {
+                // Adjust the height offset in case the consumed delta Y is less than what was
+                // recorded as available delta Y in the pre-scroll.
+                val oldHeightOffset = state.heightOffset
+                state.heightOffset += available.y
+                return Offset(0f, state.heightOffset - oldHeightOffset)
+            }
+            return Offset.Zero
+        }
+
+        override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+            var result = super.onPostFling(consumed, available)
+            // Check if the app bar is partially collapsed/expanded.
+            // Note that we don't check for 0f due to float precision with the collapsedFraction
+            // calculation.
+            if (state.collapsedFraction > 0.01f && state.collapsedFraction < 1f) {
+                result += flingToolbar(
+                    state = state,
+                    initialVelocity = available.y,
+                    flingAnimationSpec = flingAnimationSpec
+                )
+                snapToolbar(state)
+            }
+            return result
+        }
+
+    }
+
+}
+
+private suspend fun flingToolbar(
+    state: CollapsingToolbarScrollState,
+    initialVelocity: Float,
+    flingAnimationSpec: DecayAnimationSpec<Float>?,
+): Velocity {
+    var remainingVelocity = initialVelocity
+    // In case there is an initial velocity that was left after a previous user fling, animate to
+    // continue the motion to expand or collapse the app bar.
+    if (flingAnimationSpec != null && abs(initialVelocity) > 1f) {
+        var lastValue = 0f
+        AnimationState(
+            initialValue = 0f,
+            initialVelocity = initialVelocity,
+        )
+            .animateDecay(flingAnimationSpec) {
+                val delta = value - lastValue
+                val initialHeightOffset = state.heightOffset
+                state.heightOffset = initialHeightOffset + delta
+                val consumed = abs(initialHeightOffset - state.heightOffset)
+                lastValue = value
+                remainingVelocity = this.velocity
+                // avoid rounding errors and stop if anything is unconsumed
+                if (abs(delta - consumed) > 0.5f) {
+                    cancelAnimation()
+                }
+            }
+    }
+    return Velocity(0f, remainingVelocity)
+}
+
+private suspend fun snapToolbar(state: CollapsingToolbarScrollState) {
+    // In case the app bar motion was stopped in a state where it's partially visible, snap it to
+    // the nearest state.
+    if (state.heightOffset < 0 &&
+        state.heightOffset > state.heightOffsetLimit
+    ) {
+        AnimationState(
+            initialValue = state.heightOffset
+        ).animateTo(
+            targetValue = if (state.collapsedFraction < 0.5f) 0f else state.heightOffsetLimit,
+            animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
+        ) {
+            state.heightOffset = value
+        }
+    }
+}
+
+@Composable
+fun rememberToolbarScrollBehavior() = CollapsingToolbarScrollBehavior(
+    state = rememberToolbarScrollState(
+        initialHeightOffsetLimit = -Float.MAX_VALUE
+    ),
+    flingAnimationSpec = rememberSplineBasedDecay()
+)

--- a/component/src/main/java/am/acba/compose/components/collapsingToolbar/CollapsingToolbarScrollState.kt
+++ b/component/src/main/java/am/acba/compose/components/collapsingToolbar/CollapsingToolbarScrollState.kt
@@ -1,0 +1,101 @@
+﻿package am.acba.compose.components.collapsingToolbar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+
+/**
+ * A state object that can be hoisted to control and observe the top app bar state. The state is
+ * read and updated by a [CollapsingToolbarScrollBehavior] implementation.
+ *
+ * In most cases, this state will be created via [rememberToolbarScrollBehavior].
+ *
+ * @param initialHeightOffsetLimit the initial value for [CollapsingToolbarScrollState.heightOffsetLimit]
+ * @param initialHeightOffset the initial value for [CollapsingToolbarScrollState.heightOffset]
+ * @param initialContentOffset the initial value for [CollapsingToolbarScrollState.contentOffset]
+ */
+@Stable
+class CollapsingToolbarScrollState(
+    initialHeightOffsetLimit: Float,
+    initialHeightOffset: Float,
+    initialContentOffset: Float,
+) {
+    companion object {
+        val Saver: Saver<CollapsingToolbarScrollState, *> = listSaver(
+            save = { listOf(it.heightOffsetLimit, it.heightOffset, it.contentOffset) },
+            restore = {
+                CollapsingToolbarScrollState(
+                    initialHeightOffsetLimit = it[0],
+                    initialHeightOffset = it[1],
+                    initialContentOffset = it[2]
+                )
+            }
+        )
+    }
+
+    /**
+     * The top app bar's height offset limit in pixels, which represents the limit that a top app
+     * bar is allowed to collapse to.
+     *
+     * Use this limit to coerce the [heightOffset] value when it's updated.
+     */
+    var heightOffsetLimit by mutableStateOf(initialHeightOffsetLimit)
+
+    /**
+     * The top app bar's current height offset in pixels. This height offset is applied to the fixed
+     * height of the app bar to control the displayed height when content is being scrolled.
+     *
+     * Updates to the [heightOffset] value are coerced between zero and [heightOffsetLimit].
+     */
+    var heightOffset: Float
+        get() = _heightOffset.value
+        set(newOffset) {
+            _heightOffset.value = newOffset.coerceIn(
+                minimumValue = heightOffsetLimit,
+                maximumValue = 0f
+            )
+        }
+
+    /**
+     * The total offset of the content scrolled under the top app bar.
+     *
+     * This value is updated by a [CollapsingToolbarScrollBehavior] whenever a nested scroll connection
+     * consumes scroll events. A common implementation would update the value to be the sum of all
+     * [NestedScrollConnection.onPostScroll] `consumed.y` values.
+     */
+    var contentOffset by mutableStateOf(initialContentOffset)
+
+    /**
+     * A value that represents the collapsed height percentage of the app bar.
+     *
+     * A `0.0` represents a fully expanded bar, and `1.0` represents a fully collapsed bar (computed
+     * as [heightOffset] / [heightOffsetLimit]).
+     */
+    val collapsedFraction: Float
+        get() = if (heightOffsetLimit != 0f) {
+            heightOffset / heightOffsetLimit
+        } else {
+            0f
+        }
+
+    private var _heightOffset = mutableStateOf(initialHeightOffset)
+
+}
+
+@Composable
+internal fun rememberToolbarScrollState(
+    initialHeightOffsetLimit: Float = -Float.MAX_VALUE,
+    initialHeightOffset: Float = 0f,
+    initialContentOffset: Float = 0f
+) = rememberSaveable(saver = CollapsingToolbarScrollState.Saver) {
+    CollapsingToolbarScrollState(
+        initialHeightOffsetLimit,
+        initialHeightOffset,
+        initialContentOffset
+    )
+}

--- a/component/src/main/java/am/acba/compose/theme/TypographyTokens.kt
+++ b/component/src/main/java/am/acba/compose/theme/TypographyTokens.kt
@@ -28,7 +28,8 @@ data class TypographyTokens(
     val heading5Bold: TextStyle = TextStyle(
         fontFamily = FontFamily.DefaultFontFamily,
         fontWeight = FontWeight.Bold,
-        fontSize = 22.sp
+        fontSize = 22.sp,
+        lineHeight = 33.sp
     ),
     val heading6Bold: TextStyle = TextStyle(
         fontFamily = FontFamily.DefaultFontFamily,


### PR DESCRIPTION
…onents

This commit introduces a new `CollapsingToolbar` composable and its supporting components: `CollapsingToolbarScrollBehavior` and `CollapsingToolbarScrollState`.

Key changes:
- **New `CollapsingToolbar` Composable:**
    - Allows for a toolbar that collapses and expands with scroll gestures.
    - Supports a title, actions, central content, and additional content.
    - The title scales and fades based on the collapsed fraction.
    - Includes a default back navigation icon.
- **New `CollapsingToolbarScrollBehavior`:**
    - Manages the nested scroll connection for the `CollapsingToolbar`.
    - Handles pre-scroll and post-scroll events to update the toolbar's state.
    - Implements fling and snap animations for a smooth user experience.
- **New `CollapsingToolbarScrollState`:**
    - Holds the state for the `CollapsingToolbar`, including height offset, content offset, and collapsed fraction.
    - Provides a `Saver` for state restoration.
- **New `rememberToolbarScrollBehavior` Composable:**
    - A utility function to easily create and remember a `CollapsingToolbarScrollBehavior`.
- **ToolbarScreen Update:**
    - The `ToolbarScreen.kt` has been updated to demonstrate the usage of the new `CollapsingToolbar`.
    - It now features a `LazyColumn` with list items to showcase the collapsing behavior.
- **Typography Update:**
    - Added `lineHeight` to `heading5Bold` in `TypographyTokens.kt`.
- **Component Availability:**
    - `TOOLBAR_COMPOSE` in `ComponentTypeEnum.kt` is now marked as ready.