### PR TITLE
Refactor(CurrencyInput): Remove focus change action

### DIFF
--- a/component/src/main/java/am/acba/component/currencyInput/CurrencyInput.kt
+++ b/component/src/main/java/am/acba/component/currencyInput/CurrencyInput.kt
@@ -526,7 +526,6 @@ class CurrencyInput @JvmOverloads constructor(
         binding.amount.editText?.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             if (binding.amount.editText?.editableText?.isNotEmpty() == true) formatAmountAfterFocusChange(hasFocus)
             setupBackgroundsByFocusChange(hasFocus)
-            mAction?.invoke(hasFocus)
         }
     }
 


### PR DESCRIPTION
The `mAction` invocation, which was previously triggered on focus change in the `CurrencyInput` component, has been removed. This simplifies the focus change listener by removing the external callback.