### PR TITLE
Fix CurrencyInput amount validation

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,6 +13,9 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="Design-system-and-components.ACBA_design_system_and_components.app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/component/src/main/java/am/acba/component/currencyInput/CurrencyInput.kt
+++ b/component/src/main/java/am/acba/component/currencyInput/CurrencyInput.kt
@@ -221,8 +221,8 @@ class CurrencyInput @JvmOverloads constructor(
     fun validateAmount() {
         val amount = getFloatAmount()
         val text = binding.amount.editText?.text ?: ""
-        val isBelowMin = amount < minAmount
-        val isAboveMax = amount > maxAmount
+        val isBelowMin = minAmount != 0.0 && amount < minAmount
+        val isAboveMax = maxAmount != 0.0 && amount > maxAmount
         if (text.isEmpty()) isFirstFocusable = true
         isValidAmount = text.isEmpty() || !(isBelowMin || isAboveMax)
 


### PR DESCRIPTION
The amount validation in `CurrencyInput` was not correctly handling cases where `minAmount` or `maxAmount` were set to 0.0. This change updates the validation logic to only check against `minAmount` and `maxAmount` if they are not equal to 0.0.